### PR TITLE
refactor: use TypeScript path alias for cleaner imports

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,12 +1,12 @@
 ---
-import Contact from '../components/Contact.astro';
-import Feature from '../components/Feature.astro';
-import Footer from '../components/Footer.astro';
-import Menu from '../components/Menu.astro';
-import Principal from '../components/Principal.astro';
-import Prototype from '../components/Prototype.astro';
-import ValueProposal from '../components/ValueProposal.astro';
-import Layout from '../layouts/Layout.astro';
+import Contact from '@/components/Contact.astro';
+import Feature from '@/components/Feature.astro';
+import Footer from '@/components/Footer.astro';
+import Menu from '@/components/Menu.astro';
+import Principal from '@/components/Principal.astro';
+import Prototype from '@/components/Prototype.astro';
+import ValueProposal from '@/components/ValueProposal.astro';
+import Layout from '@/layouts/Layout.astro';
 ---
 
 <Layout title="Landing Page Shelf">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,9 @@
 {
-  "extends": "astro/tsconfigs/strict"
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths":{
+      "@/*": ["./src/*"]
+    }
+  }
 }


### PR DESCRIPTION
Configure TypeScript paths to alias the './src' folder, replacing relative imports with cleaner, more readable ones.