### PR TITLE
feat(analytics): add tracking for visits, interactions, and form subm…

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -5,6 +5,52 @@ import ProjectHub from "@/components/ui/ProjectHub.astro";
 import LayoutSection from "@/layouts/LayoutSection.astro";
 ---
 
+<script>
+    import { AnalyticNames, updateAnalytic, type Cookie } from "@/lib/analytics/analyticsHub";
+
+document.addEventListener("DOMContentLoaded", async () => {
+    const visitsElement: HTMLParagraphElement = document.getElementById("metric-visits-amount") as HTMLParagraphElement;
+    const submissionsElement: HTMLParagraphElement = document.getElementById("metric-forms-sent-amount") as HTMLParagraphElement;
+    const interactionsElement: HTMLParagraphElement = document.getElementById("metric-interactions-amount") as HTMLParagraphElement;
+
+    const cookie: Cookie = {
+        name: "visited",
+        value: "true"
+    }
+    await updateAnalytic(AnalyticNames.PageVisits, 1, cookie);
+
+
+    // ---- Fill metric cards. ----
+    await fetch("/api/analytics", {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json"
+        }
+    })
+    .then((response) => {
+        if (!response.ok)
+            return;
+
+        response.json().then((result) => {
+            result.forEach((analytic: any) => {
+                if (analytic.name === AnalyticNames.PageVisits) {
+                    visitsElement.textContent = analytic.count;
+                }
+                else if (analytic.name === AnalyticNames.FormSubmissions) {
+                    submissionsElement.textContent = analytic.count;
+                }
+                else if (analytic.name === AnalyticNames.UserInteractions) {
+                    interactionsElement.textContent = analytic.count;
+                }
+            })
+        });
+    })
+    .catch((error) => {
+        console.log(error);
+    })
+})
+</script>
+
 <LayoutSection title='contact' height={1117}>
     <div class="wrapper">
         <h1>Contacto & Información</h1>

--- a/src/components/Principal.astro
+++ b/src/components/Principal.astro
@@ -5,13 +5,32 @@ import LayoutSection from "@/layouts/LayoutSection.astro";
 import { Image } from "astro:assets";
 ---
 
+<script>
+    import { AnalyticNames, updateAnalytic, type Cookie } from "@/lib/analytics/analyticsHub";
+    const contactButton: HTMLLinkElement = document.getElementById("contact-button") as HTMLLinkElement;
+
+    const cookie: Cookie = {
+        name: "interacted",
+        value: "true"
+    }
+    contactButton.addEventListener("click", async () => {
+        await updateAnalytic(AnalyticNames.UserInteractions, 1, cookie);
+
+        // HACK: Update new value manually in the analytic card.
+        const analyticCard: HTMLParagraphElement = document.getElementById("metric-interactions-amount") as HTMLParagraphElement;
+        const newValue: number = parseInt(analyticCard.textContent ?? "0") + 1;
+        analyticCard.textContent = newValue.toString();
+    });
+
+</script>
+
 <LayoutSection title="principal" height={843}>
     <div class="containerPrincipal">
         <div class="left">
             <IconApp />
             <h1>Shelf</h1>
             <p>La mejor herramienta para la gestión de tu inventario</p>
-            <a href="#contact">Contactanos</a>
+            <a id="contact-button" href="#contact">Contactanos</a>
         </div>
         <div class="right">
             <div class="w-auto h-auto">

--- a/src/components/ui/ContactForm.astro
+++ b/src/components/ui/ContactForm.astro
@@ -29,6 +29,11 @@ import { validateForm } from "@/lib/validation/validation.ts";
             clearTimeout(timeoutId)
             if (response.ok) {
                 form.reset();
+
+                // HACK: Update new value manually in the analytic card.
+                const analyticCard: HTMLParagraphElement = document.getElementById("metric-forms-sent-amount") as HTMLParagraphElement;
+                const newValue: number = parseInt(analyticCard.textContent ?? "0") + 1;
+                analyticCard.textContent = newValue.toString();
             }
             showDialogResult(response.ok, response.ok ? "success" : "error");
 

--- a/src/lib/analytics/analyticsHub.ts
+++ b/src/lib/analytics/analyticsHub.ts
@@ -1,0 +1,46 @@
+export enum AnalyticNames {
+    FormSubmissions = "FormSubmissions",
+    UserInteractions = "UserInteractions",
+    PageVisits = "PageVisits",
+}
+
+export type Cookie = {
+    name: string,
+    value: string
+}
+
+function getCookie(name: string) {
+    let value = "; " + document.cookie;
+    let parts = value.split("; " + name + "=");
+    if (parts.length === 2) return parts.pop()?.split(";").shift();
+}
+
+function setCookie(cookie: Cookie, days = 365) {
+    const d = new Date();
+    d.setTime(d.getTime() + (days * 24 * 60 * 60 * 1000));
+    let expires = "expires=" + d.toUTCString();
+    document.cookie = cookie.name + "=" + cookie.value + ";" + expires + ";path=/";
+}
+
+export async function updateAnalytic(name: AnalyticNames, quantity: number, cookie?: Cookie) {
+    const dataToUpdate = JSON.stringify({
+        name: AnalyticNames[name],
+        quantity
+    });
+
+    const actionCookie = getCookie(cookie?.name ?? ""); // Check if it's a new user doing the action
+
+    if (!actionCookie) {
+        await fetch("/api/analytics", {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: dataToUpdate
+        }).then((response) => {
+            if (cookie)
+                setCookie(cookie);
+            return response.ok; // TODO: Update automatically UserInteractions metric card.
+        }).catch(() => { return false; })
+    }
+}

--- a/src/lib/database/analyticsRepository.ts
+++ b/src/lib/database/analyticsRepository.ts
@@ -1,0 +1,73 @@
+import { dbInfo, supabase } from "@/lib/database/supabase";
+import type { PostgrestError } from "@supabase/supabase-js";
+
+export type Analytic = {
+    name: string,
+    count: number,
+}
+
+export type AnalyticResponse = {
+    data: Analytic | Analytic[],
+    error: PostgrestError | null
+}
+
+function parseAnalytic(rawData: any): Analytic {
+    const data: Analytic = {
+        name: rawData.name,
+        count: rawData[0].count as number
+    }
+    return data;
+}
+
+function parseAnalytics(rawData: any): Analytic[] {
+    const analytics: Analytic[] = [
+        {
+            name: rawData[0].name,
+            count: rawData[0].count
+        },
+        {
+            name: rawData[1].name,
+            count: rawData[1].count
+        },
+        {
+            name: rawData[2].name,
+            count: rawData[2].count
+        },
+    ];
+    return analytics;
+}
+
+export async function getAnalytic(eventName: string): Promise<AnalyticResponse> {
+    const { data, error } = await supabase.schema(dbInfo.schema)
+        .from(dbInfo.analyticsTable)
+        .select("count")
+        .eq("name", eventName);
+
+    const analytic = parseAnalytic(data);
+    return { data: analytic, error: error };
+}
+
+export async function getAnalytics(): Promise<AnalyticResponse> {
+    const { data, error } = await supabase.schema(dbInfo.schema)
+        .from(dbInfo.analyticsTable)
+        .select("*");
+
+    const analytics = parseAnalytics(data);
+    return { data: analytics, error: error };
+}
+
+export async function updateAnalytic(name: string, quantity?: number): Promise<PostgrestError | null> {
+    const response: AnalyticResponse = await getAnalytic(name);
+
+    if (response.error) return response.error;
+
+    const currentValue: Analytic = response.data as Analytic;
+    const quantityToAdd: number = quantity ? quantity : 1; // Quantity to add to the analytic.
+
+    const { error } = await supabase.schema(dbInfo.schema)
+        .from(dbInfo.analyticsTable)
+        .update({ count: currentValue.count + quantityToAdd })
+        .eq("name", name);
+
+    return error;
+}

--- a/src/lib/database/supabase.ts
+++ b/src/lib/database/supabase.ts
@@ -8,4 +8,5 @@ export const supabase = createClient(
 export const dbInfo = {
     schema: import.meta.env.SUPABASE_SCHEMA,
     formsTable: import.meta.env.SUPABASE_FORMS_TABLE,
+    analyticsTable: import.meta.env.SUPABASE_ANALYTICS_TABLE
 }

--- a/src/pages/api/analytics.ts
+++ b/src/pages/api/analytics.ts
@@ -1,0 +1,48 @@
+export const prerender = false;
+import { getAnalytic, getAnalytics, updateAnalytic, type AnalyticResponse } from "@/lib/database/analyticsRepository";
+import type { APIRoute } from "astro";
+
+function createResponse(body: any, statusCode: number): Response {
+    return new Response(JSON.stringify(body), {
+        status: statusCode,
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    });
+}
+
+export const GET: APIRoute = async ({ url }) => {
+    try {
+        const param = url.searchParams.get("analytic") as string;
+
+        const analyticResponse: AnalyticResponse = param
+            ? await getAnalytic(param)
+            : await getAnalytics();
+
+        if (analyticResponse.error) {
+            return createResponse("An unexpected error occurred.", 500)
+        }
+
+        return createResponse(analyticResponse.data, 200);
+
+    } catch {
+        return createResponse("An unexpected error occurred.", 500);
+    }
+}
+
+export const PATCH: APIRoute = async ({ request }) => {
+    try {
+        const body = await request.json();
+
+        const error = await updateAnalytic(body.name, body.quantity);
+
+        if (error) {
+            return createResponse("Error while updating analytics.", 500);
+        }
+
+        return createResponse("Analytic data found.", 200);
+
+    } catch {
+        return createResponse("An unexpected error occurred.", 500);
+    }
+}


### PR DESCRIPTION
Implement analytics to count:

**Website visits:** Uses a cookie to track unique users and avoid double-counting.
**Interactions:** Tracks interactions with the call-to-action (CTA) button. 
**Form submissions:** Captures and records the number of submitted forms.

Introduced basic cookie handling for excluding repeat visits from the same user (except for form submissions).